### PR TITLE
fix: Version range requires double quotes

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Add `sentry` dependency to your `pubspec.yaml`:
 
 ```yaml
 dependencies:
-  sentry: >=3.0.0 <4.0.0
+  sentry: ">=3.0.0 <4.0.0"
 ```
 
 In your Dart code, import `package:sentry/sentry.dart` and create a `SentryClient` using the DSN issued by Sentry.io:


### PR DESCRIPTION
Configuration range require double quotes:

Current install instructions:
<img width="202" alt="image" src="https://user-images.githubusercontent.com/1633368/72688927-5c281b00-3b0c-11ea-9fd4-1165f584730c.png">

With quotes:
<img width="201" alt="image" src="https://user-images.githubusercontent.com/1633368/72688942-76fa8f80-3b0c-11ea-96c4-7dd92346d9c4.png">

